### PR TITLE
calculate theta

### DIFF
--- a/lib/options_library/option_calculator.rb
+++ b/lib/options_library/option_calculator.rb
@@ -28,6 +28,20 @@ module Option
         phi( d_one( underlying, strike, time, interest, sigma, dividend ) ) / ( underlying * sigma * sqrt(time) )
       end
 	
+      # computes the call price sensitivity to a change in time
+      def theta_call( underlying, strike, time, interest, sigma, dividend )
+        term1 = underlying * phi( d_one( underlying, strike, time, interest, sigma, dividend ) ) * sigma / ( 2 * sqrt(time) )
+        term2 = interest * strike * exp(-1.0 * interest * time) * norm_sdist( d_two( underlying, strike, time, interest, sigma, dividend ) )
+        ( - term1 - term2 ) / 365.0
+      end
+
+      # computes the put price sensitivity to a change in time
+      def theta_put( underlying, strike, time, interest, sigma, dividend )
+        term1 = underlying * phi( d_one( underlying, strike, time, interest, sigma, dividend ) ) * sigma / ( 2 * sqrt(time) )
+        term2 = interest * strike * exp(-1.0 * interest * time) * norm_sdist( - d_two( underlying, strike, time, interest, sigma, dividend ) )
+        ( - term1 + term2 ) / 365.0
+      end
+
       # computes the option price sensitivity to a change in volatility
       def vega( underlying, strike, time, interest, sigma, dividend )
         0.01 * underlying * sqrt(time) * phi(d_one(underlying, strike, time, interest, sigma, dividend))

--- a/lib/options_library/option_model.rb
+++ b/lib/options_library/option_model.rb
@@ -11,6 +11,7 @@ module Option
     # A map to define methods to call based on option_type
     CALC_PRICE_METHODS  = { :call=>Calculator.method('price_call'),       :put=>Calculator.method('price_put') }
     CALC_DELTA_METHODS  = { :call=>Calculator.method('delta_call'),       :put=>Calculator.method('delta_put') }
+    CALC_THETA_METHODS  = { :call=>Calculator.method('theta_call'),       :put=>Calculator.method('theta_put') }
     IMPLIED_VOL_METHODS = { :call=>Calculator.method('implied_vol_call'), :put=>Calculator.method('implied_vol_put') }
 
     attr_accessor :underlying, :strike, :time, :interest, :sigma, :dividend, :option_type
@@ -36,6 +37,10 @@ module Option
 
     def calc_gamma
       Calculator.gamma(underlying, strike, time, interest, sigma, dividend)
+    end
+
+    def calc_theta
+      CALC_THETA_METHODS[option_type].call(underlying, strike, time, interest, sigma, dividend)
     end
 
     def calc_vega


### PR DESCRIPTION
I was surprised to see the theta missing. Feel free to change my patch (especially to remove the duplication of formulas/terms).

The difference between call and put:
- call (positive d_two in norm_sdist), put (negative d_two in norm_sdist) in term2
- call (term2 is subtracted), put (term2 is added) in the final calculation
